### PR TITLE
Fix cruft update and change the diff order

### DIFF
--- a/cruft/_commands/diff.py
+++ b/cruft/_commands/diff.py
@@ -41,6 +41,7 @@ def diff(
             cruft_state=cruft_state,
             project_dir=project_dir,
             checkout=checkout,
+            update_deleted_paths=True,
         )
 
         # Then we create a new tree with each file in the template that also exist
@@ -49,7 +50,6 @@ def diff(
             relative_path = path.relative_to(remote_template_dir)
             local_path = project_dir / relative_path
             destination = local_template_dir / relative_path
-
             if path.is_file():
                 shutil.copy(str(local_path), str(destination))
             else:
@@ -57,7 +57,7 @@ def diff(
                 destination.chmod(local_path.stat().st_mode)
 
         # Finally we can compute and print the diff.
-        diff = utils.diff.get_diff(remote_template_dir, local_template_dir)
+        diff = utils.diff.get_diff(local_template_dir, remote_template_dir)
 
         if diff.strip():
             has_diff = True
@@ -78,6 +78,6 @@ def diff(
                 # to git diff so that they can benefit from coloration and paging.
                 # Ouputing absolute paths is less of a concern although it would be
                 # better to find a way to make git shrink those paths.
-                utils.diff.display_diff(remote_template_dir, local_template_dir)
+                utils.diff.display_diff(local_template_dir, remote_template_dir)
 
     return not (has_diff and exit_code)

--- a/cruft/_commands/update.py
+++ b/cruft/_commands/update.py
@@ -2,7 +2,7 @@ import json
 from pathlib import Path
 from subprocess import DEVNULL, PIPE, CalledProcessError, run  # nosec
 from tempfile import TemporaryDirectory
-from typing import Optional
+from typing import Optional, Set
 
 import click
 import typer
@@ -42,7 +42,7 @@ def update(
         repo_dir = tmpdir / "repo"
         current_template_dir = tmpdir / "current_template"
         new_template_dir = tmpdir / "new_template"
-
+        deleted_paths: Set[Path] = set()
         # Clone the template
         repo = utils.cookiecutter.get_cookiecutter_repo(cruft_state["template"], repo_dir, checkout)
         last_commit = repo.head.object.hexsha
@@ -64,6 +64,8 @@ def update(
             project_dir=project_dir,
             cookiecutter_input=cookiecutter_input,
             checkout=cruft_state["commit"],
+            deleted_paths=deleted_paths,
+            update_deleted_paths=True,
         )
         new_context = utils.generate.cookiecutter_template(
             output_dir=new_template_dir,
@@ -72,6 +74,7 @@ def update(
             project_dir=project_dir,
             cookiecutter_input=cookiecutter_input,
             checkout=last_commit,
+            deleted_paths=deleted_paths,
         )
 
         # Given the two versions of the cookiecutter outputs based

--- a/cruft/_commands/utils/diff.py
+++ b/cruft/_commands/utils/diff.py
@@ -20,9 +20,15 @@ def get_diff(repo0: Path, repo1: Path) -> str:
     # --- a/tmp/tmpmp34g21y/remote/.coveragerc
     # +++ b/tmp/tmpmp34g21y/local/.coveragerc
     # We don't want this as we may need to apply the diff later on.
-    diff = diff.replace("a" + str(repo0), "a")
-    diff = diff.replace("b" + str(repo1), "b")
-
+    diff = diff.replace("a" + str(repo0), "a").replace("b" + str(repo1), "b")
+    # This replacement is needed for renamed/moved files to be recognized properly
+    # Renamed files in the diff don't have the "a" or "b" prefix and instead look like
+    # /tmp/tmpmp34g21y/remote/.coveragerc
+    # If we replace repo paths which are like /tmp/tmpmp34g21y/remote
+    # we would end up with /.coveragerc which doesn't work.
+    # We also need to replace the trailing slash. As a result, we only do
+    # this after the above replacement is made as the trailing slash is needed there.
+    diff = diff.replace(str(repo0) + "/", "").replace(str(repo1) + "/", "")
     return diff
 
 

--- a/cruft/_commands/utils/generate.py
+++ b/cruft/_commands/utils/generate.py
@@ -23,8 +23,12 @@ def cookiecutter_template(
     project_dir: Path = Path("."),
     cookiecutter_input: bool = False,
     checkout: Optional[str] = None,
+    deleted_paths: Set[Path] = None,
+    update_deleted_paths: bool = False,
 ) -> CookiecutterContext:
     """Generate a clean cookiecutter template in output_dir."""
+    if deleted_paths is None:
+        deleted_paths = set()
     pyproject_file = project_dir / "pyproject.toml"
     commit = checkout or repo.remotes.origin.refs["HEAD"]
 
@@ -37,7 +41,8 @@ def cookiecutter_template(
     # We also get the list of paths that were deleted from the project
     # directory but were present in the template that the project is linked against
     # This is to avoid introducing changes that won't apply cleanly to the current project.
-    deleted_paths = _get_deleted_files(output_dir, project_dir)
+    if update_deleted_paths:
+        deleted_paths.update(_get_deleted_files(output_dir, project_dir))
     # We now remove skipped and deleted paths from the project
     _remove_paths(output_dir, skip_paths | deleted_paths)
 

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 set -euxo pipefail
 
-./scripts/lint.sh
 poetry run pytest -s -n auto --cov=cruft/ --cov=tests --cov-report=term-missing ${@-} --cov-report xml --cov-report html
+./scripts/lint.sh

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -159,19 +159,19 @@ def test_diff_has_diff(
     assert stderr == ""
 
     expected_output = """diff --git a{tmpdir}/dir0/file1 b{tmpdir}/dir0/file1
-index ac3e272..eaae237 100644
+index eaae237..ac3e272 100644
 --- a{tmpdir}/dir0/file1
 +++ b{tmpdir}/dir0/file1
 @@ -1 +1 @@
--content1
-+new content 1
+-new content 1
++content1
 diff --git a{tmpdir}/file0 b{tmpdir}/file0
-index 1fc03a9..be6a56b 100644
+index be6a56b..1fc03a9 100644
 --- a{tmpdir}/file0
 +++ b{tmpdir}/file0
 @@ -1 +1 @@
--content0
-+new content 0
+-new content 0
++content0
 """
     expected_output_regex = re.escape(expected_output)
     expected_output_regex = expected_output_regex.replace(r"\{tmpdir\}", r"([^\n]*)")
@@ -227,5 +227,5 @@ def test_diff_checkout(capfd, tmpdir):
     assert stderr == ""
     assert "--- a/README.md" in stdout
     assert "+++ b/README.md" in stdout
-    assert "-Updated again" in stdout
-    assert "+Updated" in stdout
+    assert "+Updated again" in stdout
+    assert "-Updated" in stdout

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -222,6 +222,25 @@ def test_update_strict(cruft_runner, cookiecutter_dir_updated):
     assert "cruft has been updated" in result.stdout
 
 
+def test_update_when_new_file(cruft_runner, cookiecutter_dir):
+    result = cruft_runner(
+        ["update", "--project-dir", str(cookiecutter_dir), "-c", "new-file"], input="y\n"
+    )
+    assert result.exit_code == 0
+    assert (cookiecutter_dir / "new-file").exists()
+    assert "cruft has been updated" in result.stdout
+
+
+def test_update_when_file_moved(cruft_runner, cookiecutter_dir):
+    result = cruft_runner(
+        ["update", "--project-dir", str(cookiecutter_dir), "-c", "file-moved"], input="y\n"
+    )
+    assert result.exit_code == 0
+    assert (cookiecutter_dir / "NEW-README.md").exists()
+    assert not (cookiecutter_dir / "README.md").exists()
+    assert "cruft has been updated" in result.stdout
+
+
 def test_update_interactive_view_no_changes(cruft_runner, cookiecutter_dir):
     result = cruft_runner(
         ["update", "--project-dir", str(cookiecutter_dir), "-c", "no-changes"], input="v\ny\n"


### PR DESCRIPTION
This commit provides the following fixes -

Fixes https://github.com/cruft/cruft/issues/67
Fixes cruft not detecting new files

Fixes https://github.com/cruft/cruft/issues/53
Fixes cruft not being able to handle moves

Fixes cruft diff order so that the base repo is the project repo.
This way any changes from the upstream template can be outputted to
a diff file and applied if needed.