### PR TITLE
fix: Handle a/NEW and b/OLD when editing diffs

### DIFF
--- a/cruft/_commands/utils/diff.py
+++ b/cruft/_commands/utils/diff.py
@@ -20,7 +20,11 @@ def get_diff(repo0: Path, repo1: Path) -> str:
     # --- a/tmp/tmpmp34g21y/remote/.coveragerc
     # +++ b/tmp/tmpmp34g21y/local/.coveragerc
     # We don't want this as we may need to apply the diff later on.
-    diff = diff.replace("a" + str(repo0), "a").replace("b" + str(repo1), "b")
+    # Note that diff headers contain repo0 and repo1 with both "a" and "b"
+    # prefixes: headers for new files have a/repo1, headers for deleted files
+    # have b/repo0.
+    for repo in [repo0, repo1]:
+        diff = diff.replace("a" + str(repo), "a").replace("b" + str(repo), "b")
     # This replacement is needed for renamed/moved files to be recognized properly
     # Renamed files in the diff don't have the "a" or "b" prefix and instead look like
     # /tmp/tmpmp34g21y/remote/.coveragerc

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,31 @@
+from pathlib import Path
+
+from cruft._commands import utils
+
+
+def test_get_diff_with_add(tmp_path: Path):
+    repo0 = tmp_path / "repo0"
+    repo1 = tmp_path / "repo1"
+
+    repo0.mkdir()
+    repo1.mkdir()
+
+    (repo1 / "file").touch()
+
+    diff = utils.diff.get_diff(repo0, repo1)
+
+    assert diff.startswith("diff --git a/file b/file")
+
+
+def test_get_diff_with_delete(tmp_path: Path):
+    repo0 = tmp_path / "repo0"
+    repo1 = tmp_path / "repo1"
+
+    repo0.mkdir()
+    repo1.mkdir()
+
+    (repo0 / "file").touch()
+
+    diff = utils.diff.get_diff(repo0, repo1)
+
+    assert diff.startswith("diff --git a/file b/file")


### PR DESCRIPTION
Closes #82 