### PR TITLE
Indent .cruft.json by two spaces instead of four

### DIFF
--- a/cruft/_commands/utils/cruft.py
+++ b/cruft/_commands/utils/cruft.py
@@ -35,5 +35,5 @@ def is_project_updated(repo: Repo, current_commit: str, latest_commit: str, stri
 
 
 def json_dumps(cruft_state: Dict[str, Any]) -> str:
-    text = json.dumps(cruft_state, ensure_ascii=False, indent=4, separators=(",", ": "))
+    text = json.dumps(cruft_state, ensure_ascii=False, indent=2, separators=(",", ": "))
     return text + "\n"


### PR DESCRIPTION
Follow-up to #88 
Closes #89 