### PR TITLE
Warn when pyproject.toml exists but cannot be read

### DIFF
--- a/cruft/_commands/utils/generate.py
+++ b/cruft/_commands/utils/generate.py
@@ -1,9 +1,9 @@
 import os
-from warnings import warn
 from pathlib import Path
 from shutil import move, rmtree
 from tempfile import TemporaryDirectory
 from typing import Optional, Set, Union
+from warnings import warn
 
 from cookiecutter.generate import generate_files
 from git import Repo

--- a/cruft/_commands/utils/generate.py
+++ b/cruft/_commands/utils/generate.py
@@ -100,7 +100,9 @@ def _get_skip_paths(cruft_state: CruftState, pyproject_file: Path) -> Set[Path]:
         pyproject_cruft = toml.loads(pyproject_file.read_text()).get("tool", {}).get("cruft", {})
         skip_cruft.extend(pyproject_cruft.get("skip", []))
     elif pyproject_file.is_file():
-        warn("pyproject.toml is present in repo, but `toml` package is not installed. Cruft configuration may be ignored.")
+        warn(
+            "pyproject.toml is present in repo, but `toml` package is not installed. Cruft configuration may be ignored."
+        )
     return set(map(Path, skip_cruft))
 
 

--- a/cruft/_commands/utils/generate.py
+++ b/cruft/_commands/utils/generate.py
@@ -101,7 +101,8 @@ def _get_skip_paths(cruft_state: CruftState, pyproject_file: Path) -> Set[Path]:
         skip_cruft.extend(pyproject_cruft.get("skip", []))
     elif pyproject_file.is_file():
         warn(
-            "pyproject.toml is present in repo, but `toml` package is not installed. Cruft configuration may be ignored."
+            "pyproject.toml is present in repo, but `toml` package is not installed. "
+            "Cruft configuration may be ignored."
         )
     return set(map(Path, skip_cruft))
 

--- a/cruft/_commands/utils/generate.py
+++ b/cruft/_commands/utils/generate.py
@@ -1,4 +1,5 @@
 import os
+from warnings import warn
 from pathlib import Path
 from shutil import move, rmtree
 from tempfile import TemporaryDirectory
@@ -98,6 +99,8 @@ def _get_skip_paths(cruft_state: CruftState, pyproject_file: Path) -> Set[Path]:
     if toml and pyproject_file.is_file():
         pyproject_cruft = toml.loads(pyproject_file.read_text()).get("tool", {}).get("cruft", {})
         skip_cruft.extend(pyproject_cruft.get("skip", []))
+    elif pyproject_file.is_file():
+        warn("pyproject.toml is present in repo, but `toml` package is not installed. Cruft configuration may be ignored.")
     return set(map(Path, skip_cruft))
 
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -4,6 +4,7 @@ import pytest
 
 from cruft import exceptions
 from cruft._commands import utils
+from cruft._commands.utils.cruft import CruftState
 
 
 def test_get_diff_with_add(tmp_path: Path):
@@ -92,3 +93,9 @@ def test_remove_paths_folder(tmp_path: Path):
     utils.generate._remove_paths(repo0, {"tests", "file"})
     assert not (repo0 / "tests").exists()
     assert not (repo0 / "file").exists()
+
+
+def test_warn_if_cant_read_pyproject_toml(monkeypatch):
+    monkeypatch.setattr(utils.generate, "toml", None)
+    with pytest.warns(UserWarning, match="`toml` package is not installed"):
+        utils.generate._get_skip_paths({}, Path(__file__))

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -4,7 +4,6 @@ import pytest
 
 from cruft import exceptions
 from cruft._commands import utils
-from cruft._commands.utils.cruft import CruftState
 
 
 def test_get_diff_with_add(tmp_path: Path):


### PR DESCRIPTION
This should help users when files aren't being ignored.