### PR TITLE
Add support for generating the project with always skipped files on u…

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,8 +74,7 @@ If there are any updates, cruft will have you review them before applying. If yo
 and update the `.cruft.json` file for you.
 
 !!! tip
-    Sometimes certain files just aren't good fits for updating. Such as test cases or `__init__` files. You can tell cruft to always skip updating these files on a project by project basis by added them
-    to a skip section within your .cruft.json file:
+    Sometimes certain files just aren't good fits for updating. Such as test cases or `__init__` files. You can tell cruft to always skip updating these files on a project by generating project with `--skip cruft/__init__.py --skip tests` arguments or manually adding them to a skip section within your `.cruft.json` file:
 
         {
             "template": "https://github.com/timothycrosley/cookiecutter-python",

--- a/cruft/_cli.py
+++ b/cruft/_cli.py
@@ -1,7 +1,7 @@
 """This module defines CLI interactions when using `cruft`."""
 import json
 from pathlib import Path
-from typing import Optional
+from typing import Optional, List
 
 import typer
 
@@ -100,6 +100,12 @@ def create(
         show_default=False,
         help="Overwrite the contents of the output directory if it already exists",
     ),
+    skip: Optional[List[str]] = typer.Option(
+        None,
+        "--skip",
+        show_default=False,
+        help="Default files/pattern to skip on update"
+    )
 ) -> None:
     _commands.create(
         template_git_url,
@@ -111,6 +117,7 @@ def create(
         directory=directory,
         checkout=checkout,
         overwrite_if_exists=overwrite_if_exists,
+        skip=skip
     )
 
 

--- a/cruft/_cli.py
+++ b/cruft/_cli.py
@@ -1,7 +1,7 @@
 """This module defines CLI interactions when using `cruft`."""
 import json
 from pathlib import Path
-from typing import Optional, List
+from typing import List, Optional
 
 import typer
 

--- a/cruft/_cli.py
+++ b/cruft/_cli.py
@@ -101,11 +101,8 @@ def create(
         help="Overwrite the contents of the output directory if it already exists",
     ),
     skip: Optional[List[str]] = typer.Option(
-        None,
-        "--skip",
-        show_default=False,
-        help="Default files/pattern to skip on update"
-    )
+        None, "--skip", show_default=False, help="Default files/pattern to skip on update"
+    ),
 ) -> None:
     _commands.create(
         template_git_url,
@@ -117,7 +114,7 @@ def create(
         directory=directory,
         checkout=checkout,
         overwrite_if_exists=overwrite_if_exists,
-        skip=skip
+        skip=skip,
     )
 
 

--- a/cruft/_commands/create.py
+++ b/cruft/_commands/create.py
@@ -19,7 +19,7 @@ def create(
     directory: Optional[str] = None,
     checkout: Optional[str] = None,
     overwrite_if_exists: bool = False,
-    skip: Optional[List[str]] = None
+    skip: Optional[List[str]] = None,
 ) -> Path:
     """Expand a Git based Cookiecutter template into a new project on disk."""
     template_git_url = utils.cookiecutter.resolve_template_url(template_git_url)
@@ -64,8 +64,6 @@ def create(
 
         # After generating the project - save the cruft state
         # into the cruft file.
-        (project_dir / ".cruft.json").write_text(
-            utils.cruft.json_dumps(cruft_content)
-        )
+        (project_dir / ".cruft.json").write_text(utils.cruft.json_dumps(cruft_content))
 
         return project_dir

--- a/cruft/_commands/create.py
+++ b/cruft/_commands/create.py
@@ -1,6 +1,6 @@
 from pathlib import Path
 from tempfile import TemporaryDirectory
-from typing import Any, Dict, Optional
+from typing import Any, Dict, Optional, List
 
 from cookiecutter.generate import generate_files
 
@@ -19,6 +19,7 @@ def create(
     directory: Optional[str] = None,
     checkout: Optional[str] = None,
     overwrite_if_exists: bool = False,
+    skip: Optional[List[str]] = None
 ) -> Path:
     """Expand a Git based Cookiecutter template into a new project on disk."""
     template_git_url = utils.cookiecutter.resolve_template_url(template_git_url)
@@ -50,18 +51,21 @@ def create(
             )
         )
 
+        cruft_content = {
+            "template": template_git_url,
+            "commit": last_commit,
+            "checkout": checkout,
+            "context": context,
+            "directory": directory,
+        }
+
+        if skip:
+            cruft_content["skip"] = skip
+
         # After generating the project - save the cruft state
         # into the cruft file.
         (project_dir / ".cruft.json").write_text(
-            utils.cruft.json_dumps(
-                {
-                    "template": template_git_url,
-                    "commit": last_commit,
-                    "checkout": checkout,
-                    "context": context,
-                    "directory": directory,
-                }
-            )
+            utils.cruft.json_dumps(cruft_content)
         )
 
         return project_dir

--- a/cruft/_commands/create.py
+++ b/cruft/_commands/create.py
@@ -1,6 +1,6 @@
 from pathlib import Path
 from tempfile import TemporaryDirectory
-from typing import Any, Dict, Optional, List
+from typing import Any, Dict, List, Optional
 
 from cookiecutter.generate import generate_files
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -42,7 +42,7 @@ def test_check_examples(tmpdir, project_dir):
     os.chdir(project_dir)
     verify_and_test_examples(cruft.check)
 
-def test_create_stores_checkout_value(tmpdir):
+def test_create_with_skips(tmpdir):
     tmpdir.chdir()
     skips = ["setup.cfg"]
     cruft.create(
@@ -53,7 +53,8 @@ def test_create_stores_checkout_value(tmpdir):
         json.load((tmpdir / "python_project_name" / ".cruft.json").open("r"))["skip"] == skips
     )
 
-def test_create_with_skip(value, tmpdir):
+@pytest.mark.parametrize("value", ["main", None])
+def test_create_stores_checkout_value(value, tmpdir):
     tmpdir.chdir()
 
     cruft.create(

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -42,9 +42,18 @@ def test_check_examples(tmpdir, project_dir):
     os.chdir(project_dir)
     verify_and_test_examples(cruft.check)
 
+def test_create_stores_checkout_value(tmpdir):
+    tmpdir.chdir()
+    skips = ["setup.cfg"]
+    cruft.create(
+        "https://github.com/timothycrosley/cookiecutter-python", Path(tmpdir), skip=skips
+    )
 
-@pytest.mark.parametrize("value", ["main", None])
-def test_create_stores_checkout_value(value, tmpdir):
+    assert (
+        json.load((tmpdir / "python_project_name" / ".cruft.json").open("r"))["skip"] == skips
+    )
+
+def test_create_with_skip(value, tmpdir):
     tmpdir.chdir()
 
     cruft.create(

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -42,16 +42,14 @@ def test_check_examples(tmpdir, project_dir):
     os.chdir(project_dir)
     verify_and_test_examples(cruft.check)
 
+
 def test_create_with_skips(tmpdir):
     tmpdir.chdir()
     skips = ["setup.cfg"]
-    cruft.create(
-        "https://github.com/timothycrosley/cookiecutter-python", Path(tmpdir), skip=skips
-    )
+    cruft.create("https://github.com/timothycrosley/cookiecutter-python", Path(tmpdir), skip=skips)
 
-    assert (
-        json.load((tmpdir / "python_project_name" / ".cruft.json").open("r"))["skip"] == skips
-    )
+    assert json.load((tmpdir / "python_project_name" / ".cruft.json").open("r"))["skip"] == skips
+
 
 @pytest.mark.parametrize("value", ["main", None])
 def test_create_stores_checkout_value(value, tmpdir):


### PR DESCRIPTION
It's quite useful functionality if I want to provide runnable sample application with boilerplate for logging, metrics, tests etc... but I don't want it to be ever updated.

This way I can reuse old create command from bash history instead of editing every cruft.json file manually.