### PR TITLE
Issue/123: add shorter clone time to cruft check

### DIFF
--- a/cruft/_commands/check.py
+++ b/cruft/_commands/check.py
@@ -19,8 +19,12 @@ def check(
     cruft_state = json.loads(cruft_file.read_text())
     with TemporaryDirectory() as cookiecutter_template_dir:
         repo = utils.cookiecutter.get_cookiecutter_repo(
-            cruft_state["template"], Path(cookiecutter_template_dir), checkout,
-            filter="blob:none", no_checkout=True, single_branch=True)
+            cruft_state["template"],
+            Path(cookiecutter_template_dir),
+            checkout,
+            filter="blob:none",
+            no_checkout=True,
+        )
         last_commit = repo.head.object.hexsha
         if utils.cruft.is_project_updated(repo, cruft_state["commit"], last_commit, strict):
             typer.secho(

--- a/cruft/_commands/check.py
+++ b/cruft/_commands/check.py
@@ -19,8 +19,8 @@ def check(
     cruft_state = json.loads(cruft_file.read_text())
     with TemporaryDirectory() as cookiecutter_template_dir:
         repo = utils.cookiecutter.get_cookiecutter_repo(
-            cruft_state["template"], Path(cookiecutter_template_dir), checkout
-        )
+            cruft_state["template"], Path(cookiecutter_template_dir), checkout,
+            filter="blob:none", no_checkout=True, single_branch=True)
         last_commit = repo.head.object.hexsha
         if utils.cruft.is_project_updated(repo, cruft_state["commit"], last_commit, strict):
             typer.secho(

--- a/cruft/_commands/utils/cookiecutter.py
+++ b/cruft/_commands/utils/cookiecutter.py
@@ -38,7 +38,10 @@ def resolve_template_url(url: str) -> str:
 
 
 def get_cookiecutter_repo(
-    template_git_url: str, cookiecutter_template_dir: Path, checkout: Optional[str] = None, **clone_kwargs
+    template_git_url: str,
+    cookiecutter_template_dir: Path,
+    checkout: Optional[str] = None,
+    **clone_kwargs,
 ) -> Repo:
     try:
         repo = Repo.clone_from(template_git_url, cookiecutter_template_dir, **clone_kwargs)

--- a/cruft/_commands/utils/cookiecutter.py
+++ b/cruft/_commands/utils/cookiecutter.py
@@ -38,10 +38,10 @@ def resolve_template_url(url: str) -> str:
 
 
 def get_cookiecutter_repo(
-    template_git_url: str, cookiecutter_template_dir: Path, checkout: Optional[str] = None
+    template_git_url: str, cookiecutter_template_dir: Path, checkout: Optional[str] = None, **clone_kwargs
 ) -> Repo:
     try:
-        repo = Repo.clone_from(template_git_url, cookiecutter_template_dir)
+        repo = Repo.clone_from(template_git_url, cookiecutter_template_dir, **clone_kwargs)
     except GitCommandError as error:
         raise InvalidCookiecutterRepository(
             template_git_url, f"Failed to clone the repo. {error.stderr.strip()}"


### PR DESCRIPTION
As mentioned in #123 
Use a series of git clone options to only download the log and not the actual repo.

This is especially useful for large cookiecutter templates. 
See this example where the change saved almost 5 seconds.
![image](https://user-images.githubusercontent.com/4355368/132352412-cee49c65-3ab7-4756-a5c9-49458092630b.png)
