### PR TITLE
Accept cookiecutter arguments on the command line for update

### DIFF
--- a/cruft/_cli.py
+++ b/cruft/_cli.py
@@ -240,6 +240,12 @@ def update(
             " repository (but no other changes)"
         ),
     ),
+    extra_context: str = typer.Option(
+        "{}",
+        "--extra-context",
+        help="A JSON string describing any extra context to pass to cookiecutter.",
+        show_default=False,
+    ),
 ) -> None:
     if not _commands.update(
         project_dir=project_dir,
@@ -250,6 +256,7 @@ def update(
         checkout=checkout,
         strict=strict,
         allow_untracked_files=allow_untracked_files,
+        extra_context=json.loads(extra_context),
     ):
         raise typer.Exit(1)
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -418,6 +418,34 @@ def test_update_refresh_private_variables_from_template(
     assert result.exit_code == 0
 
 
+@pytest.mark.parametrize(
+    "template_version",
+    [
+        "input",
+        "input-updated",
+    ],
+)
+def test_update_extra_context(
+    cruft_runner,
+    cookiecutter_dir_input,
+    capfd,
+    template_version,
+):
+    result = cruft_runner(
+        ["update", "--project-dir", cookiecutter_dir_input.as_posix()]
+        + ["-c", template_version, '--extra-context={"input":"extra-context"}'],
+        input="v\ny\n",
+    )
+    git_diff_captured = capfd.readouterr()
+    if template_version == "input-updated":
+        assert "-Initial" in git_diff_captured.out
+        assert "+Updated" in git_diff_captured.out
+    assert "-Input from cookiecutter: some-input" in git_diff_captured.out
+    assert "+Input from cookiecutter: extra-context" in git_diff_captured.out
+    assert "cruft has been updated" in result.stdout
+    assert result.exit_code == 0
+
+
 @pytest.mark.parametrize("args,expected_exit_code", [([], 0), (["--exit-code"], 1), (["-e"], 1)])
 def test_diff_has_diff(args, expected_exit_code, cruft_runner, cookiecutter_dir):
     (cookiecutter_dir / "README.md").write_text("changed content\n")


### PR DESCRIPTION
This PR adds support for providing cookiecutter arguments on the command line for `cruft update`. If any arguments are provided on the command line, `cruft update` will always render the template regardless of whether the user has requested to update to a new template version or not. This would allow users to use `cruft update` to modify template variables for existing projects as requested in #57.

This PR builds on https://github.com/cruft/cruft/pull/159/.