### PR TITLE
Allow overriding template url

### DIFF
--- a/cruft/_cli.py
+++ b/cruft/_cli.py
@@ -233,6 +233,16 @@ def update(
             " repository (but no other changes)"
         ),
     ),
+    override_template_url: Optional[str] = typer.Option(
+        None,
+        "--override-template-url",
+        "-ot",
+        help=(
+            "Use this URL instead of the one in the .cruft.json file."
+            "This allows checking out in ci mode using a token for example."
+        ),
+        show_default=False,
+    ),
 ) -> None:
     if not _commands.update(
         project_dir=project_dir,
@@ -242,6 +252,7 @@ def update(
         checkout=checkout,
         strict=strict,
         allow_untracked_files=allow_untracked_files,
+        override_template_url=override_template_url,
     ):
         raise typer.Exit(1)
 

--- a/cruft/_commands/update.py
+++ b/cruft/_commands/update.py
@@ -21,6 +21,7 @@ def update(
     checkout: Optional[str] = None,
     strict: bool = True,
     allow_untracked_files: bool = False,
+    override_template_url: Optional[str] = None,
 ) -> bool:
     """Update specified project's cruft to the latest and greatest release."""
     cruft_file = utils.cruft.get_cruft_file(project_dir)
@@ -36,6 +37,9 @@ def update(
         return False
 
     cruft_state = json.loads(cruft_file.read_text())
+
+    # replace cruft_state template url with the one from env variable
+    cruft_state["template_url"] = override_template_url / cruft_state["template_url"]
 
     with AltTemporaryDirectory() as tmpdir_:
         # Initial setup

--- a/cruft/_commands/update.py
+++ b/cruft/_commands/update.py
@@ -38,9 +38,6 @@ def update(
 
     cruft_state = json.loads(cruft_file.read_text())
 
-    # replace cruft_state template url with the one from env variable
-    cruft_state["template_url"] = override_template_url / cruft_state["template_url"]
-
     with AltTemporaryDirectory() as tmpdir_:
         # Initial setup
         tmpdir = Path(tmpdir_)
@@ -50,7 +47,7 @@ def update(
         deleted_paths: Set[Path] = set()
         # Clone the template
         with utils.cookiecutter.get_cookiecutter_repo(
-            cruft_state["template"], repo_dir, checkout
+            override_template_url or cruft_state["template_url"], repo_dir, checkout
         ) as repo:
             last_commit = repo.head.object.hexsha
 


### PR DESCRIPTION
We faced an issue when we wanted to create a Github bot to create PRs automatically after running `cruft update` : 
- all our cruft templates are indicated using a `git` url, working with ssh
- when we are in our ci (GH bot) context, we don't have an ssh key but a Github access token

This PRs adds a way to override the template_url, just for a single update : 
```
cruft update --override-template-url https://{gh_token}/template.git
```

This way our ci can override it, using an https url.