### PR TITLE
Specify git diff `--{src,dst}-prefix` for consistent diff prefixes

### DIFF
--- a/cruft/_commands/utils/diff.py
+++ b/cruft/_commands/utils/diff.py
@@ -52,8 +52,8 @@ def get_diff(repo0: Path, repo1: Path) -> str:
     for repo in [repo0_str, repo1_str]:
         # Make repo look like a NIX absolute path.
         repo = sub("/[a-z]:", "", repo)
-        diff = diff.replace(f"{DIFF_SRC_PREFIX}{repo}", "a").replace(
-            f"{DIFF_DST_PREFIX}{repo}", "b"
+        diff = diff.replace(f"{DIFF_SRC_PREFIX}{repo}", DIFF_SRC_PREFIX).replace(
+            f"{DIFF_DST_PREFIX}{repo}", DIFF_DST_PREFIX
         )
 
     # This replacement is needed for renamed/moved files to be recognized properly

--- a/cruft/_commands/utils/diff.py
+++ b/cruft/_commands/utils/diff.py
@@ -5,10 +5,24 @@ from typing import List
 
 from cruft import exceptions
 
+DIFF_SRC_PREFIX = "CRUFT_TEMPLATE_SRC"
+DIFF_DST_PREFIX = "CRUFT_TEMPLATE_DST"
+
 
 def _git_diff(*args: str) -> List[str]:
     # https://git-scm.com/docs/git-diff#Documentation/git-diff.txt---binary support for binary patch
-    return ["git", "-c", "diff.noprefix=", "diff", "--no-index", "--relative", "--binary", *args]
+    return [
+        "git",
+        "-c",
+        "diff.noprefix=",
+        "diff",
+        "--no-index",
+        "--relative",
+        "--binary",
+        f"--src-prefix={DIFF_SRC_PREFIX}/",
+        f"--src-prefix={DIFF_DST_PREFIX}/",
+        *args,
+    ]
 
 
 def get_diff(repo0: Path, repo1: Path) -> str:
@@ -38,7 +52,9 @@ def get_diff(repo0: Path, repo1: Path) -> str:
     for repo in [repo0_str, repo1_str]:
         # Make repo look like a NIX absolute path.
         repo = sub("/[a-z]:", "", repo)
-        diff = diff.replace("a" + repo, "a").replace("b" + repo, "b")
+        diff = diff.replace(f"{DIFF_SRC_PREFIX}{repo}", "a").replace(
+            f"{DIFF_DST_PREFIX}{repo}", "b"
+        )
 
     # This replacement is needed for renamed/moved files to be recognized properly
     # Renamed files in the diff don't have the "a" or "b" prefix and instead look like

--- a/cruft/_commands/utils/diff.py
+++ b/cruft/_commands/utils/diff.py
@@ -5,8 +5,8 @@ from typing import List
 
 from cruft import exceptions
 
-DIFF_SRC_PREFIX = "CRUFT_TEMPLATE_SRC"
-DIFF_DST_PREFIX = "CRUFT_TEMPLATE_DST"
+DIFF_SRC_PREFIX = "upstream-template-old"
+DIFF_DST_PREFIX = "upstream-template-new"
 
 
 def _git_diff(*args: str) -> List[str]:

--- a/cruft/_commands/utils/diff.py
+++ b/cruft/_commands/utils/diff.py
@@ -20,7 +20,7 @@ def _git_diff(*args: str) -> List[str]:
         "--relative",
         "--binary",
         f"--src-prefix={DIFF_SRC_PREFIX}/",
-        f"--src-prefix={DIFF_DST_PREFIX}/",
+        f"--dst-prefix={DIFF_DST_PREFIX}/",
         *args,
     ]
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -273,8 +273,8 @@ def test_diff_checkout(capfd, tmpdir):
     stderr = captured.err
 
     assert stderr == ""
-    assert "--- CRUFT_TEMPLATE_SRC/README.md" in stdout
-    assert "+++ CRUFT_TEMPLATE_DST/README.md" in stdout
+    assert "--- upstream-template-old/README.md" in stdout
+    assert "+++ upstream-template-new/README.md" in stdout
     assert "+Updated again" in stdout
     assert "-Updated" in stdout
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -273,8 +273,8 @@ def test_diff_checkout(capfd, tmpdir):
     stderr = captured.err
 
     assert stderr == ""
-    assert "--- a/README.md" in stdout
-    assert "+++ b/README.md" in stdout
+    assert "--- CRUFT_TEMPLATE_SRC/README.md" in stdout
+    assert "+++ CRUFT_TEMPLATE_DST/README.md" in stdout
     assert "+Updated again" in stdout
     assert "-Updated" in stdout
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -206,17 +206,17 @@ def test_diff_has_diff(
 
     assert stderr == ""
 
-    expected_output = """diff --git a{tmpdir}/dir0/file1 b{tmpdir}/dir0/file1
+    expected_output = """diff --git upstream-template-old{tmpdir}/dir0/file1 upstream-template-new{tmpdir}/dir0/file1
 index eaae237..ac3e272 100644
---- a{tmpdir}/dir0/file1
-+++ b{tmpdir}/dir0/file1
+--- upstream-template-old{tmpdir}/dir0/file1
++++ upstream-template-new{tmpdir}/dir0/file1
 @@ -1 +1 @@
 -new content 1
 +content1
-diff --git a{tmpdir}/file0 b{tmpdir}/file0
+diff --git upstream-template-old{tmpdir}/file0 upstream-template-new{tmpdir}/file0
 index be6a56b..1fc03a9 100644
---- a{tmpdir}/file0
-+++ b{tmpdir}/file0
+--- upstream-template-old{tmpdir}/file0
++++ upstream-template-new{tmpdir}/file0
 @@ -1 +1 @@
 -new content 0
 +content0

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -17,7 +17,9 @@ def test_get_diff_with_add(tmp_path: Path):
 
     diff = utils.diff.get_diff(repo0, repo1)
 
-    assert diff.startswith("diff --git a/file b/file")
+    assert diff.startswith(
+        "diff --git CRUFT_TEMPLATE_SRC/file CRUFT_TEMPLATE_DST/file"
+    )
 
 
 def test_get_diff_with_delete(tmp_path: Path):
@@ -31,7 +33,9 @@ def test_get_diff_with_delete(tmp_path: Path):
 
     diff = utils.diff.get_diff(repo0, repo1)
 
-    assert diff.startswith("diff --git a/file b/file")
+    assert diff.startswith(
+        "diff --git CRUFT_TEMPLATE_SRC/file CRUFT_TEMPLATE_DST/file"
+    )
 
 
 def test_get_diff_with_unicode(project_dir):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -18,7 +18,7 @@ def test_get_diff_with_add(tmp_path: Path):
     diff = utils.diff.get_diff(repo0, repo1)
 
     assert diff.startswith(
-        "diff --git CRUFT_TEMPLATE_SRC/file CRUFT_TEMPLATE_DST/file"
+        "diff --git upstream-template-old/file upstream-template-new/file"
     )
 
 
@@ -34,7 +34,7 @@ def test_get_diff_with_delete(tmp_path: Path):
     diff = utils.diff.get_diff(repo0, repo1)
 
     assert diff.startswith(
-        "diff --git CRUFT_TEMPLATE_SRC/file CRUFT_TEMPLATE_DST/file"
+        "diff --git upstream-template-old/file upstream-template-new/file"
     )
 
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -17,9 +17,7 @@ def test_get_diff_with_add(tmp_path: Path):
 
     diff = utils.diff.get_diff(repo0, repo1)
 
-    assert diff.startswith(
-        "diff --git upstream-template-old/file upstream-template-new/file"
-    )
+    assert diff.startswith("diff --git upstream-template-old/file upstream-template-new/file")
 
 
 def test_get_diff_with_delete(tmp_path: Path):
@@ -33,9 +31,7 @@ def test_get_diff_with_delete(tmp_path: Path):
 
     diff = utils.diff.get_diff(repo0, repo1)
 
-    assert diff.startswith(
-        "diff --git upstream-template-old/file upstream-template-new/file"
-    )
+    assert diff.startswith("diff --git upstream-template-old/file upstream-template-new/file")
 
 
 def test_get_diff_with_unicode(project_dir):


### PR DESCRIPTION
The existing `git diff` invocation produces different prefixes when
git's `diff.mnemonicprefix` config option is set to `true`.

Specifying diff prefixes avoids unexpected git diff output prefixes from
a user's git configuration.

Fixes #177