### PR TITLE
Recursively clone submodules in templates

### DIFF
--- a/cruft/_commands/utils/cookiecutter.py
+++ b/cruft/_commands/utils/cookiecutter.py
@@ -44,9 +44,6 @@ def get_cookiecutter_repo(
     checkout: Optional[str] = None,
     **clone_kwargs,
 ) -> Repo:
-    # By default we allow for submodules in the template
-    if "multi_options" not in clone_kwargs:
-        clone_kwargs["multi_options"] = ["--recurse-submodules"]
     try:
         repo = Repo.clone_from(template_git_url, cookiecutter_template_dir, **clone_kwargs)
     except GitCommandError as error:
@@ -61,6 +58,7 @@ def get_cookiecutter_repo(
                 template_git_url,
                 f"Failed to check out the reference {checkout}. {error.stderr.strip()}",
             )
+    repo.submodule_update(recursive=True, force_reset=True)
     return repo
 
 

--- a/cruft/_commands/utils/cookiecutter.py
+++ b/cruft/_commands/utils/cookiecutter.py
@@ -45,8 +45,8 @@ def get_cookiecutter_repo(
     **clone_kwargs,
 ) -> Repo:
     # By default we allow for submodules in the template
-    if 'multi_options' not in clone_kwargs:
-        clone_kwargs['multi_options'] = ['--recurse-submodules']
+    if "multi_options" not in clone_kwargs:
+        clone_kwargs["multi_options"] = ["--recurse-submodules"]
     try:
         repo = Repo.clone_from(template_git_url, cookiecutter_template_dir, **clone_kwargs)
     except GitCommandError as error:

--- a/cruft/_commands/utils/cookiecutter.py
+++ b/cruft/_commands/utils/cookiecutter.py
@@ -44,6 +44,9 @@ def get_cookiecutter_repo(
     checkout: Optional[str] = None,
     **clone_kwargs,
 ) -> Repo:
+    # By default we allow for submodules in the template
+    if 'multi_options' not in clone_kwargs:
+        clone_kwargs['multi_options'] = ['--recurse-submodules']
     try:
         repo = Repo.clone_from(template_git_url, cookiecutter_template_dir, **clone_kwargs)
     except GitCommandError as error:

--- a/cruft/_commands/utils/generate.py
+++ b/cruft/_commands/utils/generate.py
@@ -39,6 +39,7 @@ def cookiecutter_template(
     commit = checkout or repo.remotes.origin.refs["HEAD"]
 
     repo.head.reset(commit=commit, working_tree=True)
+    repo.submodule_update(recursive=True, force_reset=True)
 
     assert repo.working_dir is not None  # nosec B101 (allow assert for type checking)
     context = _generate_output(cruft_state, Path(repo.working_dir), cookiecutter_input, output_dir)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -62,6 +62,17 @@ def cookiecutter_dir_input(tmpdir):
     )
 
 
+@pytest.fixture
+def cookiecutter_dir_submodule(tmpdir):
+    yield Path(
+        cruft.create(
+            "https://github.com/ottonemo/cookiecutter-test-submodules",
+            Path(tmpdir),
+            checkout="master",
+        )
+    )
+
+
 def test_create(cruft_runner, tmpdir):
     result = cruft_runner(
         [
@@ -715,3 +726,39 @@ def test_local_extension_update(cruft_runner, tmpdir):
     assert result.exit_code == 0
     with open(tmpdir / "test" / "README.md") as f:
         assert "Updated11" in f.read()
+
+
+def test_submodule_create(cruft_runner, cookiecutter_dir_submodule):
+    # the submodule was properly cloned if the file of the submodule exists
+    assert (cookiecutter_dir_submodule / "submodule" / "test-file").exists()
+
+
+def test_submodule_update_has_submodule_diff(cruft_runner, cookiecutter_dir_submodule, capfd):
+    # the diff during an update should include the submodule changes
+    result = cruft_runner(
+        ["update", "--project-dir", cookiecutter_dir_submodule.as_posix(), "-c", "updated"],
+        input="v\ny\n",
+    )
+    assert result.exit_code == 0
+
+    git_diff_captured = capfd.readouterr()
+
+    assert "current_template/submodule/test-file" in git_diff_captured.out
+    assert "new_template/submodule/test-file" in git_diff_captured.out
+    assert "@@ -1 +1 @@" in git_diff_captured.out
+    assert "-revision 1" in git_diff_captured.out
+    assert "+revision 2" in git_diff_captured.out
+
+    assert "cruft has been updated" in result.stdout
+
+
+def test_submodule_diff_includes_submodule(cruft_runner, cookiecutter_dir_submodule):
+    with open(cookiecutter_dir_submodule / "submodule" / "test-file", "w") as f:
+        f.write("revision 3")
+
+    result = cruft_runner(["diff", "--project-dir", cookiecutter_dir_submodule.as_posix()])
+    assert result.exit_code == 0
+
+    assert "@@ -1 +1 @@" in result.stdout
+    assert "-revision 3" in result.stdout
+    assert "+revision 1" in result.stdout

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -66,9 +66,9 @@ def cookiecutter_dir_input(tmpdir):
 def cookiecutter_dir_submodule(tmpdir):
     yield Path(
         cruft.create(
-            "https://github.com/ottonemo/cookiecutter-test-submodules",
+            "https://github.com/cruft/cookiecutter-test",
             Path(tmpdir),
-            checkout="master",
+            checkout="submodules",
         )
     )
 
@@ -736,7 +736,13 @@ def test_submodule_create(cruft_runner, cookiecutter_dir_submodule):
 def test_submodule_update_has_submodule_diff(cruft_runner, cookiecutter_dir_submodule, capfd):
     # the diff during an update should include the submodule changes
     result = cruft_runner(
-        ["update", "--project-dir", cookiecutter_dir_submodule.as_posix(), "-c", "updated"],
+        [
+            "update",
+            "--project-dir",
+            cookiecutter_dir_submodule.as_posix(),
+            "-c",
+            "submodules-updated",
+        ],
         input="v\ny\n",
     )
     assert result.exit_code == 0


### PR DESCRIPTION
It would be immensely practical to further reduce cruft by allowing to reference submodules in templates. One such use-case would be the inclusion of boiler-plate IAC definitions which want to be tied to a specific template commit while avoiding the hassle of git submodules in all template instances.

While there is [an open issue](https://github.com/cookiecutter/cookiecutter/issues/1041) to support git submodules in cookiecutter, that does not matter anyway since cruft does the VCS handling on its own.

This change makes it possible to use submodules in templates by
a) cloning repositories with `--recurse-submodules` by default
b) calling `git submodule update` when comparing template states

There is added runtime cost to this but I think the reduction of organizational overhead justifies this.