### PR TITLE
Add docker image

### DIFF
--- a/.github/workflows/docker_publish.yml
+++ b/.github/workflows/docker_publish.yml
@@ -1,0 +1,92 @@
+---
+name: Docker publish
+
+on:
+  release:
+    types: [released]
+
+jobs:
+  build-docker:
+    name: Build and push docker images
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    env:
+      dockerhub_image: cruft/cruft
+      github_image: ghcr.io/cruft/cruft
+      version: ${{ github.event.release.tag_name }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Install poetry
+        run: pipx install poetry
+
+      - name: Setup Python
+        uses: actions/setup-python@v3
+        with:
+          python-version: "3.7"
+          cache: "poetry"
+
+      - name: Install dependencies
+        run: |
+          poetry env use "3.7"
+          poetry install
+
+      - name: Bump version number
+        run: poetry version ${{ env.version }}
+
+      - name: Build package
+        run: poetry build
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKER_HUB_USERNAME }}
+          password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
+
+      - name: Login to Github image registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Setup qemu
+        uses: docker/setup-qemu-action@v2 # Action page: <https://github.com/docker/setup-qemu-action>
+
+      - name: Setup Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Get slugs
+        uses: gacts/github-slug@v1 # Action page: <https://github.com/gacts/github-slug>
+        id: slug
+
+      - name: Build image
+        uses: docker/build-push-action@v4 # Action page: <https://github.com/docker/build-push-action>
+        with:
+          context: .
+          file: docker/Dockerfile
+          push: true
+          platforms: linux/amd64,linux/386,linux/arm64,linux/arm/v7 # linux/arm/v6 unavailable now <https://github.com/docker-library/python/issues/823>
+          build-args: |
+            CRUFT_VERSION=${{ env.version }}
+          labels: |
+            org.opencontainers.image.url="https://github.com/cruft/cruft"
+            org.opencontainers.image.documentation="https://github.com/cruft/cruft"
+            org.opencontainers.image.source="https://github.com/cruft/cruft"
+            org.opencontainers.image.version=${{ github.event.release.tag_name }}
+            org.opencontainers.image.vendor="cruft"
+            org.opencontainers.image.title="cruft"
+            version=${{ env.version }}
+          tags: |
+            ${{ env.dockerhub_image }}:${{ steps.slug.outputs.version-major }}.${{ steps.slug.outputs.version-minor }}.${{ steps.slug.outputs.version-patch }}
+            ${{ env.dockerhub_image }}:${{ steps.slug.outputs.version-major }}.${{ steps.slug.outputs.version-minor }}
+            ${{ env.dockerhub_image }}:${{ steps.slug.outputs.version-major }}
+            ${{ env.dockerhub_image }}:latest
+            ${{ env.github_image }}:${{ steps.slug.outputs.version-major }}.${{ steps.slug.outputs.version-minor }}.${{ steps.slug.outputs.version-patch }}
+            ${{ env.github_image }}:${{ steps.slug.outputs.version-major }}.${{ steps.slug.outputs.version-minor }}
+            ${{ env.github_image }}:${{ steps.slug.outputs.version-major }}
+            ${{ env.github_image }}:latest

--- a/.github/workflows/docker_publish.yml
+++ b/.github/workflows/docker_publish.yml
@@ -13,7 +13,6 @@ jobs:
       contents: read
       packages: write
     env:
-      dockerhub_image: cruft/cruft
       github_image: ghcr.io/cruft/cruft
       version: ${{ github.event.release.tag_name }}
 
@@ -40,12 +39,6 @@ jobs:
 
       - name: Build package
         run: poetry build
-
-      - name: Login to Docker Hub
-        uses: docker/login-action@v2
-        with:
-          username: ${{ secrets.DOCKER_HUB_USERNAME }}
-          password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
 
       - name: Login to Github image registry
         uses: docker/login-action@v2
@@ -81,11 +74,7 @@ jobs:
             org.opencontainers.image.vendor="cruft"
             org.opencontainers.image.title="cruft"
             version=${{ env.version }}
-          tags: |
-            ${{ env.dockerhub_image }}:${{ steps.slug.outputs.version-major }}.${{ steps.slug.outputs.version-minor }}.${{ steps.slug.outputs.version-patch }}
-            ${{ env.dockerhub_image }}:${{ steps.slug.outputs.version-major }}.${{ steps.slug.outputs.version-minor }}
-            ${{ env.dockerhub_image }}:${{ steps.slug.outputs.version-major }}
-            ${{ env.dockerhub_image }}:latest
+          tags: |            
             ${{ env.github_image }}:${{ steps.slug.outputs.version-major }}.${{ steps.slug.outputs.version-minor }}.${{ steps.slug.outputs.version-patch }}
             ${{ env.github_image }}:${{ steps.slug.outputs.version-major }}.${{ steps.slug.outputs.version-minor }}
             ${{ env.github_image }}:${{ steps.slug.outputs.version-major }}

--- a/.github/workflows/docker_publish.yml
+++ b/.github/workflows/docker_publish.yml
@@ -63,7 +63,7 @@ jobs:
           context: .
           file: docker/Dockerfile
           push: true
-          platforms: linux/amd64,linux/386,linux/arm64,linux/arm/v7 # linux/arm/v6 unavailable now <https://github.com/docker-library/python/issues/823>
+          platforms: linux/amd64,linux/386,linux/arm64,linux/arm/v6,linux/arm/v7
           build-args: |
             CRUFT_VERSION=${{ env.version }}
           labels: |
@@ -74,7 +74,7 @@ jobs:
             org.opencontainers.image.vendor="cruft"
             org.opencontainers.image.title="cruft"
             version=${{ env.version }}
-          tags: |            
+          tags: |
             ${{ env.github_image }}:${{ steps.slug.outputs.version-major }}.${{ steps.slug.outputs.version-minor }}.${{ steps.slug.outputs.version-patch }}
             ${{ env.github_image }}:${{ steps.slug.outputs.version-major }}.${{ steps.slug.outputs.version-minor }}
             ${{ env.github_image }}:${{ steps.slug.outputs.version-major }}

--- a/.github/workflows/docker_publish.yml
+++ b/.github/workflows/docker_publish.yml
@@ -63,7 +63,7 @@ jobs:
           context: .
           file: docker/Dockerfile
           push: true
-          platforms: linux/amd64,linux/386,linux/arm64,linux/arm/v6,linux/arm/v7
+          platforms: linux/amd64,linux/arm64 # linux/arm/v6,linux/arm/v7,linux/386 is not supported
           build-args: |
             CRUFT_VERSION=${{ env.version }}
           labels: |

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,28 +1,28 @@
-FROM python:3.11.3-alpine
+FROM cgr.dev/chainguard/python:3.11.3-dev as builder
 
 # Cruft version should be set from CI pipeline
 ARG CRUFT_VERSION
 
-RUN apk add --no-cache ca-certificates git
-
 # Install cruft
 COPY "dist/cruft-${CRUFT_VERSION}-py3-none-any.whl" "/tmp/cruft-${CRUFT_VERSION}-py3-none-any.whl"
 
-ENV PATH="/opt/cruft:$PATH"
+ENV PYTHONPATH="/app/cruft:$PYTHONPATH"
+
+WORKDIR /app
 
 RUN set -eux; \
-    pip3 install "/tmp/cruft-${CRUFT_VERSION}-py3-none-any.whl"; \
-    cruft; \
-    rm "/tmp/cruft-${CRUFT_VERSION}-py3-none-any.whl"
+    pip install --target="/app/cruft" "/tmp/cruft-${CRUFT_VERSION}-py3-none-any.whl"; \
+    /app/cruft/bin/cruft
 
+FROM cgr.dev/chainguard/python:3.11.3-dev
 
-# Run cruft from unprivileged user
-RUN set -eux; \
-	addgroup -g 1234 -S cruft; \
-	adduser -u 1234 -S -D -G cruft -H -h /home/cruft -s /bin/sh cruft; \
-	mkdir -p /home/cruft; \
-	chown -R cruft:cruft /home/cruft
+WORKDIR /cruft
 
-USER cruft
+COPY --from=builder /app/cruft .
+
+ENV PATH="/cruft/bin/:$PATH"
+ENV PYTHONPATH="/cruft:$PYTHONPATH"
+
+WORKDIR /app
 
 ENTRYPOINT ["cruft"]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,28 @@
+FROM python:3.11.3-alpine
+
+# Cruft version should be set from CI pipeline
+ARG CRUFT_VERSION
+
+RUN apk add --no-cache ca-certificates git
+
+# Install cruft
+COPY "dist/cruft-${CRUFT_VERSION}-py3-none-any.whl" "/tmp/cruft-${CRUFT_VERSION}-py3-none-any.whl"
+
+ENV PATH="/opt/cruft:$PATH"
+
+RUN set -eux; \
+    pip3 install "/tmp/cruft-${CRUFT_VERSION}-py3-none-any.whl"; \
+    cruft; \
+    rm "/tmp/cruft-${CRUFT_VERSION}-py3-none-any.whl"
+
+
+# Run cruft from unprivileged user
+RUN set -eux; \
+	addgroup -g 1234 -S cruft; \
+	adduser -u 1234 -S -D -G cruft -H -h /home/cruft -s /bin/sh cruft; \
+	mkdir -p /home/cruft; \
+	chown -R cruft:cruft /home/cruft
+
+USER cruft
+
+ENTRYPOINT ["cruft"]


### PR DESCRIPTION
Hi there!

Adding docker images with cruft. This workflow automatically builds docker images with cruft installed and pushes them to `github packages` and `dockerhub` registries.

You need to create a `dockerhub` account, create a repository there and set `DOCKER_HUB_USERNAME` and `DOCKER_HUB_ACCESS_TOKEN` secrets in the settings page.

> Note: arm/v6 arch commented out since  python build issue https://github.com/docker-library/python/issues/823

Test images was pushed from https://github.com/jetexe/cruft/pull/2 PR:

~~- [Dockerhub](https://hub.docker.com/repository/docker/jetexe/cruft/tags)~~
- [ghcr](https://github.com/jetexe/cruft/pkgs/container/cruft)

Usage example:

```sh
# remember to run as the current user to have access to the file system.
docker run --rm -it -u"$(id -u):$(id -g)" -v"${PWD}:/app" cruft/cruft:2.14.0 check
```

Closes: #97 
