### PR TITLE
Add template flag to update command

### DIFF
--- a/cruft/_cli.py
+++ b/cruft/_cli.py
@@ -246,6 +246,12 @@ def update(
         help="A JSON string describing any extra context to pass to cookiecutter.",
         show_default=False,
     ),
+    template: Optional[str] = typer.Option(
+        None,
+        "--template",
+        "-t",
+        help="Override the template URL used to update the project",
+    ),
 ) -> None:
     if not _commands.update(
         project_dir=project_dir,
@@ -257,6 +263,7 @@ def update(
         strict=strict,
         allow_untracked_files=allow_untracked_files,
         extra_context=json.loads(extra_context),
+        template=template,
     ):
         raise typer.Exit(1)
 

--- a/cruft/_commands/update.py
+++ b/cruft/_commands/update.py
@@ -23,6 +23,7 @@ def update(
     strict: bool = True,
     allow_untracked_files: bool = False,
     extra_context: Optional[Dict[str, Any]] = None,
+    template: Optional[str] = None,
 ) -> bool:
     """Update specified project's cruft to the latest and greatest release."""
     cruft_file = utils.cruft.get_cruft_file(project_dir)
@@ -52,10 +53,9 @@ def update(
         current_template_dir = tmpdir / "current_template"
         new_template_dir = tmpdir / "new_template"
         deleted_paths: Set[Path] = set()
+        template_url = template or cruft_state["template"]
         # Clone the template
-        with utils.cookiecutter.get_cookiecutter_repo(
-            cruft_state["template"], repo_dir, checkout
-        ) as repo:
+        with utils.cookiecutter.get_cookiecutter_repo(template_url, repo_dir, checkout) as repo:
             last_commit = repo.head.object.hexsha
 
             # Bail early if the repo is already up to date and no inputs are asked


### PR DESCRIPTION
I did go ahead and solved #244 

Adds a `--template` flag to the `update` command.
This way, the template URL can contain access-tokens in CI/CD pipelines, without needing to change it in the `.cruft.json` file.

I am not sure, if this is the best way to achieve this. 
It definitely would solve our problem, but I am not sure if adding a new flag is the best solution.
Also, I am not sure if we should add this flag to all other commands.

Any feedback on this is very welcome.