### PR TITLE
Issue 246- Allow template from local repo

### DIFF
--- a/cruft/_cli.py
+++ b/cruft/_cli.py
@@ -247,9 +247,7 @@ def update(
         show_default=False,
     ),
     template_path: Optional[str] = typer.Option(
-        None,
-        "--template-repo",
-        help="Name of the template repo if it is already cloned locally"
+        None, "--template-repo", help="Name of the template repo if it is already cloned locally"
     ),
 ) -> None:
     if not _commands.update(
@@ -262,7 +260,7 @@ def update(
         strict=strict,
         allow_untracked_files=allow_untracked_files,
         extra_context=json.loads(extra_context),
-        template_path=template_path
+        template_path=template_path,
     ):
         raise typer.Exit(1)
 

--- a/cruft/_cli.py
+++ b/cruft/_cli.py
@@ -246,6 +246,11 @@ def update(
         help="A JSON string describing any extra context to pass to cookiecutter.",
         show_default=False,
     ),
+    template_path: Optional[str] = typer.Option(
+        None,
+        "--template-repo",
+        help="Name of the template repo if it is already cloned locally"
+    ),
 ) -> None:
     if not _commands.update(
         project_dir=project_dir,
@@ -257,6 +262,7 @@ def update(
         strict=strict,
         allow_untracked_files=allow_untracked_files,
         extra_context=json.loads(extra_context),
+        template_path=template_path
     ):
         raise typer.Exit(1)
 

--- a/cruft/_commands/create.py
+++ b/cruft/_commands/create.py
@@ -3,8 +3,6 @@ from typing import Any, Dict, List, Optional
 
 from cookiecutter.generate import generate_files
 
-from cruft.exceptions import InvalidCookiecutterRepository
-
 from . import utils
 from .utils import example
 from .utils.iohelper import AltTemporaryDirectory
@@ -27,48 +25,45 @@ def create(
     template_git_url = utils.cookiecutter.resolve_template_url(template_git_url)
     with AltTemporaryDirectory(directory) as cookiecutter_template_dir_str:
         cookiecutter_template_dir = Path(cookiecutter_template_dir_str)
-        try:
-            with utils.cookiecutter.get_cookiecutter_repo(
-                template_git_url, cookiecutter_template_dir, checkout
-            ) as repo:
-                last_commit = repo.head.object.hexsha
+        with utils.cookiecutter.get_cookiecutter_repo(
+            template_git_url, cookiecutter_template_dir, checkout
+        ) as repo:
+            last_commit = repo.head.object.hexsha
 
-                if directory:
-                    cookiecutter_template_dir = cookiecutter_template_dir / directory
+            if directory:
+                cookiecutter_template_dir = cookiecutter_template_dir / directory
 
-                context = utils.cookiecutter.generate_cookiecutter_context(
-                    template_git_url,
-                    cookiecutter_template_dir,
-                    config_file,
-                    default_config,
-                    extra_context,
-                    no_input,
-                )
-
-            project_dir = Path(
-                generate_files(
-                    repo_dir=cookiecutter_template_dir,
-                    context=context,
-                    overwrite_if_exists=overwrite_if_exists,
-                    output_dir=str(output_dir),
-                )
+            context = utils.cookiecutter.generate_cookiecutter_context(
+                template_git_url,
+                cookiecutter_template_dir,
+                config_file,
+                default_config,
+                extra_context,
+                no_input,
             )
 
-            cruft_content = {
-                "template": template_git_url,
-                "commit": last_commit,
-                "checkout": checkout,
-                "context": context,
-                "directory": directory,
-            }
+        project_dir = Path(
+            generate_files(
+                repo_dir=cookiecutter_template_dir,
+                context=context,
+                overwrite_if_exists=overwrite_if_exists,
+                output_dir=str(output_dir),
+            )
+        )
 
-            if skip:
-                cruft_content["skip"] = skip
+        cruft_content = {
+            "template": template_git_url,
+            "commit": last_commit,
+            "checkout": checkout,
+            "context": context,
+            "directory": directory,
+        }
 
-            # After generating the project - save the cruft state
-            # into the cruft file.
-            (project_dir / ".cruft.json").write_text(utils.cruft.json_dumps(cruft_content))
+        if skip:
+            cruft_content["skip"] = skip
 
-            return project_dir
-        except ValueError as err:
-            raise InvalidCookiecutterRepository(f"Failed to get git reference {err}")
+        # After generating the project - save the cruft state
+        # into the cruft file.
+        (project_dir / ".cruft.json").write_text(utils.cruft.json_dumps(cruft_content))
+
+        return project_dir

--- a/cruft/_commands/create.py
+++ b/cruft/_commands/create.py
@@ -2,6 +2,7 @@ from pathlib import Path
 from typing import Any, Dict, List, Optional
 
 from cookiecutter.generate import generate_files
+
 from cruft.exceptions import InvalidCookiecutterRepository
 
 from . import utils

--- a/cruft/_commands/update.py
+++ b/cruft/_commands/update.py
@@ -23,7 +23,7 @@ def update(
     strict: bool = True,
     allow_untracked_files: bool = False,
     extra_context: Optional[Dict[str, Any]] = None,
-    template_path: Optional[str] = None
+    template_path: Optional[str] = None,
 ) -> bool:
     """Update specified project's cruft to the latest and greatest release."""
 
@@ -41,8 +41,6 @@ def update(
             directory = str(Path("repo") / dir_name)
         else:
             directory = "repo"
-
-
 
     # If the project dir is a git repository, we ensure
     # that the user has a clean working directory before proceeding.
@@ -62,9 +60,7 @@ def update(
         new_template_dir = tmpdir / "new_template"
         deleted_paths: Set[Path] = set()
         # Clone the template or use already checked out repo in .cookiecutters directory
-        with utils.cookiecutter.get_cookiecutter_repo(
-            template, repo_dir, checkout
-        ) as repo:
+        with utils.cookiecutter.get_cookiecutter_repo(template, repo_dir, checkout) as repo:
             last_commit = repo.head.object.hexsha
 
             # Bail early if the repo is already up to date and no inputs are asked

--- a/cruft/_commands/utils/cookiecutter.py
+++ b/cruft/_commands/utils/cookiecutter.py
@@ -48,7 +48,7 @@ def get_cookiecutter_repo(
     if "://" in template_git.split(".")[0]:
         try:
             repo = Repo.clone_from(template_git, cookiecutter_template_dir, **clone_kwargs)
-        except (GitCommandError, ValueError) as error:
+        except GitCommandError as error:
             raise InvalidCookiecutterRepository(
                 template_git, f"Failed to clone the repo. {error.stderr.strip()}"
             )

--- a/cruft/_commands/utils/cookiecutter.py
+++ b/cruft/_commands/utils/cookiecutter.py
@@ -58,7 +58,8 @@ def get_cookiecutter_repo(
             repo = Repo(cookiecutter_template_dir)
         except (NoSuchPathError, FileNotFoundError, DistutilsFileError):
             raise InvalidCookiecutterRepository(
-                str(cookiecutter_template_dir), f"Template path is not a valid git repo."
+                str(cookiecutter_template_dir),
+                f"Template path is not a valid git repo: {cookiecutter_template_dir}",
             )
 
     if checkout is not None:

--- a/cruft/_commands/utils/cookiecutter.py
+++ b/cruft/_commands/utils/cookiecutter.py
@@ -45,7 +45,8 @@ def get_cookiecutter_repo(
     checkout: Optional[str] = None,
     **clone_kwargs,
 ) -> Repo:
-    if "://" in template_git.split(".")[0]:
+    parsed_url = urlparse(template_git)
+    if parsed_url.scheme == "http" or parsed_url.scheme == "https":
         try:
             repo = Repo.clone_from(template_git, cookiecutter_template_dir, **clone_kwargs)
         except GitCommandError as error:

--- a/cruft/_commands/utils/cookiecutter.py
+++ b/cruft/_commands/utils/cookiecutter.py
@@ -48,7 +48,7 @@ def get_cookiecutter_repo(
     if "://" in template_git.split(".")[0]:
         try:
             repo = Repo.clone_from(template_git, cookiecutter_template_dir, **clone_kwargs)
-        except GitCommandError as error:
+        except (GitCommandError, ValueError) as error:
             raise InvalidCookiecutterRepository(
                 template_git, f"Failed to clone the repo. {error.stderr.strip()}"
             )

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -5,6 +5,7 @@ from subprocess import run  # nosec
 from textwrap import dedent
 
 import pytest
+from git import Repo
 from typer.testing import CliRunner
 
 import cruft
@@ -76,7 +77,6 @@ def test_create(cruft_runner, tmpdir):
     )
     assert result.exit_code == 0
     assert result.stdout == ""
-
 
 def test_create_interactive(cruft_runner, tmpdir):
     result = cruft_runner(
@@ -327,6 +327,21 @@ def test_update_not_strict(cruft_runner, cookiecutter_dir_updated):
 
 def test_update_strict(cruft_runner, cookiecutter_dir_updated):
     result = cruft_runner(["update", "--project-dir", cookiecutter_dir_updated.as_posix(), "-y"])
+    assert result.exit_code == 0
+    assert "cruft has been updated" in result.stdout
+
+def test_update_with_template_directory(cruft_runner, cookiecutter_dir_updated, tmp_path):
+    template_dir = Path(tmp_path / "templates" / "cookiecutter-test")
+    template_dir.mkdir(parents=True)
+    Repo.clone_from("https://github.com/cruft/cookiecutter-test.git", str(template_dir))
+
+    result = cruft_runner(
+        ["update",
+         "--project-dir",
+         cookiecutter_dir_updated.as_posix(),
+         "--template-repo",
+         template_dir.as_posix(),
+         "-y"])
     assert result.exit_code == 0
     assert "cruft has been updated" in result.stdout
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -78,6 +78,7 @@ def test_create(cruft_runner, tmpdir):
     assert result.exit_code == 0
     assert result.stdout == ""
 
+
 def test_create_interactive(cruft_runner, tmpdir):
     result = cruft_runner(
         [
@@ -330,18 +331,22 @@ def test_update_strict(cruft_runner, cookiecutter_dir_updated):
     assert result.exit_code == 0
     assert "cruft has been updated" in result.stdout
 
+
 def test_update_with_template_directory(cruft_runner, cookiecutter_dir_updated, tmp_path):
     template_dir = Path(tmp_path / "templates" / "cookiecutter-test")
     template_dir.mkdir(parents=True)
     Repo.clone_from("https://github.com/cruft/cookiecutter-test.git", str(template_dir))
 
     result = cruft_runner(
-        ["update",
-         "--project-dir",
-         cookiecutter_dir_updated.as_posix(),
-         "--template-repo",
-         template_dir.as_posix(),
-         "-y"])
+        [
+            "update",
+            "--project-dir",
+            cookiecutter_dir_updated.as_posix(),
+            "--template-repo",
+            template_dir.as_posix(),
+            "-y",
+        ]
+    )
     assert result.exit_code == 0
     assert "cruft has been updated" in result.stdout
 


### PR DESCRIPTION
Added a new option --template_path to cruft update

From issue description: 
"Introduce an argument to update (and link?) --template_path to use a template that has already been checked out locally. This will help to use cruft inside secure github workflows when you do not want to pass private tokens or username and passwords."