### PR TITLE
Improve how a project can be updated to use new values of template variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,13 +34,13 @@ Many project template utilities exist that automate the copying and pasting of c
 
 cruft is different. It automates the creation of new projects like the others, but then it also helps you to manage the boilerplate through the life of the project. cruft makes sure your code stays in-sync with the template it came from for you.
 
-## Key Features:
+## Key Features
 
 * **Cookiecutter Compatible**: cruft utilizes [Cookiecutter](https://github.com/cookiecutter/cookiecutter) as its template expansion engine. Meaning it retains full compatibility with all existing [Cookiecutter](https://github.com/cookiecutter/cookiecutter) templates.
 * **Template Validation**: cruft can quickly validate whether or not a project is using the latest version of a template using `cruft check`. This check can easily be added to CI pipelines to ensure your projects stay in-sync.
 * **Automatic Template Updates**: cruft automates the process of updating code to match the latest version of a template, making it easy to utilize template improvements across many projects.
 
-## Installation:
+## Installation
 
 To get started - install `cruft` using a Python package manager:
 
@@ -55,7 +55,7 @@ OR
 `pipenv install cruft`
 
 
-## Creating a New Project:
+## Creating a New Project
 
 To create a new project using cruft run `cruft create PROJECT_URL` from the command line.
 
@@ -65,7 +65,7 @@ For example:
 
 cruft will then ask you any necessary questions to create your new project. It will use your answers to expand the provided template, and then return the directory it placed the expanded project.
 Behind the scenes, cruft uses [Cookiecutter](https://github.com/cookiecutter/cookiecutter) to do the project expansion. The only difference in the resulting output is a `.cruft.json` file that
-contains the git hash of the template used as well as the parameters specified.
+contains the git hash of the template used as well as the template variables specified.
 
 ## Updating a Project
 
@@ -100,7 +100,50 @@ and update the `.cruft.json` file for you.
             ...
         }
 
+## Updating Values of Template Variables
 
+`cruft` can also be used to update a project to use new values of template variables; avoiding the need to regenerate
+the project from sratch using `cookiecutter`.
+
+For example, imagine a project that was initially generated some while ago, and then later on, you want to change the
+values of some of the template variables, e.g. to change `use_some_feature` to `"yes"` or to change `project_name` to
+`"new-project-name"`.
+
+There are 2 ways this can be done, as described below.
+
+### Update Variables via the Command Line
+
+You can perform the update directly via the command line if you have only a handful of simple variables.
+
+This will change `use_some_feature` to `"yes"` while leaving all other variables unchanged:
+```bash
+cruft update --variables-to-update '{ "use_some_feature" : "yes" }'
+```
+
+This will change both `use_some_feature` to `"yes"` and `project_name` to `"new-project-name"` (and still leaving all
+other variables unchanged):
+```bash
+cruft update --variables-to-update '{ "use_some_feature" : "yes", "project_name" : "new-project-name" }'
+```
+
+The provided argument must be a valid JSON string (i.e. using double quotes, no trailing comma etc.).
+
+### Update Variables via a Cruft File
+
+If you prefer to use and editor or you have many or complex variables, you can also perform the changes via providing an
+updated .cruft.json.
+
+```bash
+# copy the existing cruft file to a temporary location (outside of your repo)
+cp .cruft.json ~/tmp/new-cruft.json
+
+# edit the file using your faviourite editor
+edit ~/tmp/new-cruft.json
+
+# perform the update
+# (this will also update your original .cruft.json automatically)
+cruft update --variables-to-update-file ~/tmp/new-cruft.json
+```
 
 ## Checking a Project
 

--- a/cruft/_cli.py
+++ b/cruft/_cli.py
@@ -76,7 +76,7 @@ def create(
         False,
         "--no-input",
         "-y",
-        help="Do not prompt for parameters and only use cookiecutter.json file content",
+        help="Do not prompt for template variables and only use cookiecutter.json file content",
         show_default=False,
     ),
     directory: Optional[str] = typer.Option(
@@ -190,7 +190,7 @@ def update(
         False,
         "--cookiecutter-input",
         "-i",
-        help="Prompt for cookiecutter parameters for the latest template version",
+        help="Prompt for cookiecutter template variables for the latest template version",
         show_default=False,
     ),
     refresh_private_variables: bool = typer.Option(
@@ -242,9 +242,32 @@ def update(
     ),
     extra_context: str = typer.Option(
         "{}",
+        "--variables-to-update",
         "--extra-context",
-        help="A JSON string describing any extra context to pass to cookiecutter.",
+        help=(
+            "Cookiecutter template variables to update in the format of a JSON string,"
+            ' e.g. --variables-to-update \'{ "project" : "new-name" }\'.'
+            " Using this option will update the project (including `.cruft.json`)"
+            " to use the new values of any variables specified."
+        ),
         show_default=False,
+    ),
+    extra_context_file: Path = typer.Option(
+        None,
+        "--variables-to-update-file",
+        help=(
+            "Cookiecutter template variables to update in the format of a new cruft file"
+            " (i.e. similar format as `.cruft.json`)."
+            " Using this option will parse the file as a JSON string and read"
+            " `context.cookiecutter` for any new values of variables, then use those to update"
+            " the project. As part of this process `.cruft.json` will be updated as well."
+        ),
+        show_default=False,
+        exists=True,
+        file_okay=True,
+        dir_okay=False,
+        writable=False,
+        readable=True,
     ),
 ) -> None:
     if not _commands.update(
@@ -257,12 +280,13 @@ def update(
         strict=strict,
         allow_untracked_files=allow_untracked_files,
         extra_context=json.loads(extra_context),
+        extra_context_file=extra_context_file,
     ):
         raise typer.Exit(1)
 
 
 @app.command(
-    short_help="Show the diff between the project and the current cruft template.",
+    short_help="Show the diff between the project and the current cruft template",
     help=_get_help_string(_commands.diff),
 )
 def diff(


### PR DESCRIPTION
* Use consistent terminology with cookiecutter: parameters -> template variables
* Add --variables-to-update as an alias and improve its help text
* Add --variables-to-update-file for convenience
* Update README to document how to use cruft to update a project to use new values of template variables

Builds on #167 to improve the fix to #57