### PR TITLE
implement support for local extensions update

### DIFF
--- a/cruft/_commands/utils/iohelper.py
+++ b/cruft/_commands/utils/iohelper.py
@@ -20,9 +20,15 @@ class AltTemporaryDirectory:
 
     def cleanup(self, cnt=0):
         if self._extended_path:
-            name = str(Path(self.tmpdir.name) / self._directory)
-            if name in sys.path:
-                sys.path.remove(name)
+            dir_path = Path(self.tmpdir.name) / self._directory
+            dir_name = str(dir_path)
+            if dir_name in sys.path:
+                sys.path.remove(dir_name)
+            for name, mod in list(sys.modules.items()):
+                if getattr(mod, "__file__", None):
+                    mod_path = Path(mod.__file__)
+                    if dir_path < mod_path:
+                        del sys.modules[name]
         if cnt >= 5:  # pragma: no cover
             raise RuntimeError("Could not delete TemporaryDirectory!")
         try:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -669,7 +669,11 @@ def test_local_extension(cruft_runner, tmpdir):
             "create",
             "--output-dir",
             str(tmpdir),
-            "https://github.com/cruft/cookiecutter-test",
+            # TODO: This should be reverted to the
+            # official cruft/cookiecutter-test repo once
+            # https://github.com/cruft/cookiecutter-test/pull/7
+            # has been merged
+            "https://github.com/Chilipp/cookiecutter-test",
             "--directory",
             "dir",
             "--checkout",

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -695,4 +695,8 @@ def test_local_extension_update(cruft_runner, tmpdir):
     )
     assert result.exit_code == 0
     with open(tmpdir / "test" / "README.md") as f:
-        assert "Updated11" in f.read()
+        contents = f.read()
+        # check if the text has been updated
+        assert "Updated11" in contents
+        # check if the extension has been updated
+        assert "This has been updated" in contents


### PR DESCRIPTION
This PR implements the support for an update of local extensions. Once we remove the path from `sys.path` in the cleanup step, we should also remove all modules that are in this folder from `sys.modules`

**Important notice:** Before we can merge this PR, https://github.com/cruft/cookiecutter-test/pull/7 needs to be merged and the temporary change in `test_local_extension_update` needs to be switched back to the official `cruft/cookiecutter-test` repo

closes #253