### PR TITLE
Option to Include Deleted Files with Diff

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -6,3 +6,5 @@ exclude_lines =
     pragma: no cover
     pragma: no cov_4_nix
     pragma: no cov_4_nix
+    pragma: no cov_4_nix
+    pragma: no cov_4_nix

--- a/cruft/_cli.py
+++ b/cruft/_cli.py
@@ -302,6 +302,19 @@ def diff(
         "-c",
         help=("The git reference to check against. Supports branches, tags and commit hashes."),
     ),
+    exclude_deleted_files: bool = typer.Option(
+        True,
+        "--exclude-deleted-files/--include-deleted-files",
+        help=(
+            "Control if files present in the template and missing from the project "
+            + "are included in the diff output."
+        ),
+    ),
 ) -> None:
-    if not _commands.diff(project_dir=project_dir, exit_code=exit_code, checkout=checkout):
+    if not _commands.diff(
+        project_dir=project_dir,
+        exit_code=exit_code,
+        checkout=checkout,
+        exclude_deleted_files=exclude_deleted_files,
+    ):
         raise typer.Exit(1)

--- a/cruft/_commands/diff.py
+++ b/cruft/_commands/diff.py
@@ -11,7 +11,10 @@ from .utils.iohelper import AltTemporaryDirectory
 
 
 def diff(
-    project_dir: Path = Path("."), exit_code: bool = False, checkout: Optional[str] = None
+    project_dir: Path = Path("."),
+    exit_code: bool = False,
+    checkout: Optional[str] = None,
+    exclude_deleted_files: bool = True,
 ) -> bool:
     """Show the diff between the project and the linked Cookiecutter template"""
     cruft_file = utils.cruft.get_cruft_file(project_dir)
@@ -41,7 +44,7 @@ def diff(
                 cruft_state=cruft_state,
                 project_dir=project_dir,
                 checkout=checkout,
-                update_deleted_paths=True,
+                update_deleted_paths=exclude_deleted_files,
             )
 
         # Then we create a new tree with each file in the template that also exist
@@ -50,6 +53,8 @@ def diff(
             relative_path = path.relative_to(remote_template_dir)
             local_path = project_dir / relative_path
             destination = local_template_dir / relative_path
+            if not local_path.exists():
+                continue
             if path.is_file():
                 shutil.copy(str(local_path), str(destination))
             else:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3,6 +3,7 @@ from functools import partial
 from pathlib import Path
 from subprocess import run  # nosec
 from textwrap import dedent
+from cruft._commands.utils import cookiecutter
 
 import pytest
 from typer.testing import CliRunner
@@ -661,6 +662,20 @@ def test_diff_skip_git_dir(args, expected_exit_code, cruft_runner, cookiecutter_
     print(result.stdout)
     assert result.exit_code == expected_exit_code
     assert ".git" not in result.stdout
+
+
+@pytest.mark.parametrize("expected_exit_code, include_deleted", [(0, False), (1, True)])
+def test_diff_deleted_files(expected_exit_code, include_deleted, cruft_runner, cookiecutter_dir):
+    print("cookiecutter_dir", cookiecutter_dir)
+    print(list(cookiecutter_dir.iterdir()))
+    # Delete a file from the project
+    (cookiecutter_dir / 'README.md').unlink()
+    args = ["diff", "--project-dir", cookiecutter_dir.as_posix(), "--exit-code"]
+    if include_deleted:
+        args += ['--include-deleted-files']
+    result = cruft_runner(args)
+    print(result.stdout)
+    assert result.exit_code == expected_exit_code
 
 
 def test_local_extension(cruft_runner, tmpdir):


### PR DESCRIPTION
Related to #256, this PR adds an extra flag to diff that allows files deleted from the project, but present in the template, to be included in `cruft diff` output. This is especially helpful when trying to backport cruft / cookiecutter to existing projects for compliance.

I believe the work should be mostly compatible with PR #233, given that it affects how the cookiecutter is generated and only makes small changes to the diff step.  The argument may need clarifying in the event #233 is to be merged.