### PR TITLE
Accept json file for extra_context

### DIFF
--- a/cruft/_cli.py
+++ b/cruft/_cli.py
@@ -72,6 +72,13 @@ def create(
         help="A JSON string describing any extra context to pass to cookiecutter.",
         show_default=False,
     ),
+    extra_context_file: Optional[Path] = typer.Option(
+        None,
+        "--extra-context-file",
+        "-E",
+        help="Path to a JSON file describing any extra context to pass to cookiecutter.",
+        exists=True,
+    ),
     no_input: bool = typer.Option(
         False,
         "--no-input",
@@ -110,6 +117,7 @@ def create(
         config_file=config_file,
         default_config=default_config,
         extra_context=json.loads(extra_context),
+        extra_context_file=extra_context_file,
         no_input=no_input,
         directory=directory,
         checkout=checkout,

--- a/cruft/_commands/create.py
+++ b/cruft/_commands/create.py
@@ -15,6 +15,7 @@ def create(
     config_file: Optional[Path] = None,
     default_config: bool = False,
     extra_context: Optional[Dict[str, Any]] = None,
+    extra_context_file: Optional[Path] = None,
     no_input: bool = True,
     directory: Optional[str] = None,
     checkout: Optional[str] = None,
@@ -33,6 +34,8 @@ def create(
             if directory:
                 cookiecutter_template_dir = cookiecutter_template_dir / directory
 
+            if extra_context_file:
+                extra_context = utils.cookiecutter.get_extra_context_from_file(extra_context_file)
             context = utils.cookiecutter.generate_cookiecutter_context(
                 template_git_url,
                 cookiecutter_template_dir,

--- a/cruft/_commands/utils/cookiecutter.py
+++ b/cruft/_commands/utils/cookiecutter.py
@@ -1,3 +1,4 @@
+import json
 from pathlib import Path
 from typing import Any, Dict, Optional
 from urllib.parse import urlparse
@@ -99,3 +100,11 @@ def generate_cookiecutter_context(
     context["cookiecutter"]["_template"] = template_git_url
 
     return context
+
+
+def get_extra_context_from_file(extra_context_file: Path) -> Dict[str, Any]:
+    extra_context = {}
+    if extra_context_file.exists():
+        with open(extra_context_file, "r") as f:
+            extra_context = json.load(f)
+    return extra_context

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -94,6 +94,25 @@ def test_create_interactive(cruft_runner, tmpdir):
     assert (Path(tmpdir) / "RANDOM_NAME").exists()
 
 
+def test_create_extra_context_file(cruft_runner, tmpdir):
+    extra_context_file = Path(__file__).parent / "testdata" / "unicode-data" / "extra_context.json"
+    result = cruft_runner(
+        [
+            "create",
+            "--output-dir",
+            str(tmpdir),
+            "--extra-context-file",
+            str(extra_context_file),
+            "--directory",
+            "dir",
+            "--no-input",
+            "https://github.com/cruft/cookiecutter-test",
+        ]
+    )
+    assert result.exit_code == 0
+    assert (Path(tmpdir) / "CRUFT-TEST-PROJECT").exists()
+
+
 def test_check(cruft_runner, cookiecutter_dir):
     result = cruft_runner(["check", "--project-dir", cookiecutter_dir.as_posix()])
     assert result.exit_code == 0

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -113,3 +113,9 @@ def test_warn_if_cant_read_pyproject_toml(monkeypatch):
     monkeypatch.setattr(utils.generate, "tomllib", None)
     with pytest.warns(UserWarning, match="`toml` package is not installed"):
         utils.generate._get_skip_paths({}, Path(__file__))
+
+
+def test_get_extra_context_from_file():
+    extra_context_file = Path(__file__).parent / "testdata" / "unicode-data" / "extra_context.json"
+    extra_context = utils.cookiecutter.get_extra_context_from_file(extra_context_file)
+    assert extra_context == {"project": "CRUFT-TEST-PROJECT"}

--- a/tests/testdata/unicode-data/extra_context.json
+++ b/tests/testdata/unicode-data/extra_context.json
@@ -1,0 +1,3 @@
+{
+  "project": "CRUFT-TEST-PROJECT"
+}


### PR DESCRIPTION
Added get_extra_context_from_file in cookiecutter.py to parse the extra_context json and return it to the create command.

Added an extra_context_file option to _cli.py

If the create command is called it will first see if the extra_context_file exists and if so it will parse the file and assign it to the extra_context variable.

resolves #263 