### PR TITLE
generate: Remove filtering _-prefixed keys

### DIFF
--- a/cruft/_commands/utils/generate.py
+++ b/cruft/_commands/utils/generate.py
@@ -73,17 +73,11 @@ def _generate_output(
 ) -> CookiecutterContext:
     inner_dir = project_dir / (cruft_state.get("directory") or "")
 
-    # Don't pass entries prefixed by "_" = cookiecutter extensions, not direct user intent
-    extra_context = {
-        key: value
-        for key, value in cruft_state["context"]["cookiecutter"].items()
-        if not key.startswith("_")
-    }
     new_context = generate_cookiecutter_context(
         cruft_state["template"],
         commit,
         inner_dir,
-        extra_context=extra_context,
+        extra_context=cruft_state["context"]["cookiecutter"],
         no_input=not cookiecutter_input,
     )
 


### PR DESCRIPTION
These keys are extremely useful for making the configuration less verbose at the same time avoiding Cookiecutter prompts on generation.

I have a system where my Cookiecutter extension merges a base configuration. Some base dict keys start with `_` or `__` and then the main configuration can be minimal only consisting of things overridden.

Example:

`cookiecutter.json` in template:

```json
{
    "__base": {"config": {"a": 1, "b": 2, "c": 3},
    "config": null
}
```

User's `.cruft.json`:

```json
{
{
    "checkout": null,
    "commit": "main",
    "context": {
        "cookiecutter": {
    "config": {"b": 3}
},
    "directory": null,
    "template": "..."
}
```

The resulting file (`example.json`) after merging `__base.config` with `context.cookiecutter.config`:

```json
{"config": {"a": 1, "b": 3, "c": 3}
```

I rely on applying the output of `cruft diff` a lot, so on generate the user may not get the project 100% to their liking, but it's easy to run `cruft diff` and apply the diff again to make things right after editing `.cruft.json`. I would rather that than having a huge `.cruft.json` and asking way too many questions to start a new project because the keys don't start with `_`.

The concept of having a base config and merging is a whole other thing in itself but I think it's something to implement somewhere eventually (probably in Cookiecutter itself).