### PR TITLE
Add accept hooks option

### DIFF
--- a/cruft/_cli.py
+++ b/cruft/_cli.py
@@ -111,6 +111,7 @@ def create(
     skip: Optional[List[str]] = typer.Option(
         None, "--skip", show_default=False, help="Default files/pattern to skip on update"
     ),
+    accept_hooks: bool = typer.Option(True, "--accept-hooks", help="Accept pre/post hooks"),
 ) -> None:
     _commands.create(
         template_git_url,
@@ -124,6 +125,7 @@ def create(
         checkout=checkout,
         overwrite_if_exists=overwrite_if_exists,
         skip=skip,
+        accept_hooks=accept_hooks,
     )
 
 
@@ -284,6 +286,7 @@ def update(
         writable=False,
         readable=True,
     ),
+    accept_hooks: bool = typer.Option(True, "--accept-hooks", help="Accept pre/post hooks"),
 ) -> None:
     if not _commands.update(
         project_dir=project_dir,
@@ -297,6 +300,7 @@ def update(
         allow_untracked_files=allow_untracked_files,
         extra_context=json.loads(extra_context),
         extra_context_file=extra_context_file,
+        accept_hooks=accept_hooks,
     ):
         raise typer.Exit(1)
 
@@ -318,6 +322,9 @@ def diff(
         "-c",
         help=("The git reference to check against. Supports branches, tags and commit hashes."),
     ),
+    accept_hooks: bool = typer.Option(True, "--accept-hooks", help="Accept pre/post hooks"),
 ) -> None:
-    if not _commands.diff(project_dir=project_dir, exit_code=exit_code, checkout=checkout):
+    if not _commands.diff(
+        project_dir=project_dir, exit_code=exit_code, checkout=checkout, accept_hooks=accept_hooks
+    ):
         raise typer.Exit(1)

--- a/cruft/_commands/create.py
+++ b/cruft/_commands/create.py
@@ -21,6 +21,7 @@ def create(
     checkout: Optional[str] = None,
     overwrite_if_exists: bool = False,
     skip: Optional[List[str]] = None,
+    accept_hooks: bool = True,
 ) -> Path:
     """Expand a Git based Cookiecutter template into a new project on disk."""
     template_git_url = utils.cookiecutter.resolve_template_url(template_git_url)
@@ -52,6 +53,7 @@ def create(
                 context=context,
                 overwrite_if_exists=overwrite_if_exists,
                 output_dir=str(output_dir),
+                accept_hooks=accept_hooks,
             )
         )
 
@@ -61,6 +63,7 @@ def create(
             "checkout": checkout,
             "context": context,
             "directory": directory,
+            "accept_hooks": accept_hooks,
         }
 
         if skip:

--- a/cruft/_commands/diff.py
+++ b/cruft/_commands/diff.py
@@ -11,7 +11,10 @@ from .utils.iohelper import AltTemporaryDirectory
 
 
 def diff(
-    project_dir: Path = Path("."), exit_code: bool = False, checkout: Optional[str] = None
+    project_dir: Path = Path("."),
+    exit_code: bool = False,
+    checkout: Optional[str] = None,
+    accept_hooks: Optional[bool] = None,
 ) -> bool:
     """Show the diff between the project and the linked Cookiecutter template"""
     cruft_file = utils.cruft.get_cruft_file(project_dir)
@@ -25,6 +28,11 @@ def diff(
         directory = str(Path("repo") / directory)
     else:
         directory = "repo"
+
+    if accept_hooks is None:
+        accept_hooks_bool = cruft_state.get("accept_hooks", True)
+    else:
+        accept_hooks_bool = accept_hooks
 
     with AltTemporaryDirectory(directory) as tmpdir_:
         tmpdir = Path(tmpdir_)
@@ -45,6 +53,7 @@ def diff(
                 output_dir=remote_template_dir,
                 repo=repo,
                 cruft_state=cruft_state,
+                accept_hooks=accept_hooks_bool,
                 project_dir=project_dir,
                 checkout=checkout,
                 update_deleted_paths=True,

--- a/cruft/_commands/link.py
+++ b/cruft/_commands/link.py
@@ -59,6 +59,7 @@ def link(
                     "checkout": checkout,
                     "context": context,
                     "directory": directory,
+                    "accept_hooks": True,
                 }
             )
         )

--- a/cruft/_commands/update.py
+++ b/cruft/_commands/update.py
@@ -25,6 +25,7 @@ def update(
     allow_untracked_files: bool = False,
     extra_context: Optional[Dict[str, Any]] = None,
     extra_context_file: Optional[Path] = None,
+    accept_hooks: Optional[bool] = None,
 ) -> bool:
     """Update specified project's cruft to the latest and greatest release."""
     cruft_file = utils.cruft.get_cruft_file(project_dir)
@@ -70,6 +71,12 @@ def update(
         template_git_str = cruft_state["template"]
     else:
         template_git_str = utils.cookiecutter.resolve_template_url(str(template_path))
+
+    if accept_hooks is None:
+        accept_hooks_bool = cruft_state.get("accept_hooks", True)
+    else:
+        accept_hooks_bool = accept_hooks
+
     with AltTemporaryDirectory(directory) as tmpdir_:
         # Initial setup
         tmpdir = Path(tmpdir_)
@@ -104,6 +111,7 @@ def update(
                 checkout=cruft_state["commit"],
                 deleted_paths=deleted_paths,
                 update_deleted_paths=True,
+                accept_hooks=accept_hooks_bool,
             )
             # Remove private variables from cruft_state to refresh their values
             # from the cookiecutter template config
@@ -124,6 +132,7 @@ def update(
                 cookiecutter_input=cookiecutter_input,
                 checkout=last_commit,
                 deleted_paths=deleted_paths,
+                accept_hooks=accept_hooks_bool,
             )
 
         # Given the two versions of the cookiecutter outputs based
@@ -142,6 +151,7 @@ def update(
             cruft_state["commit"] = last_commit
             cruft_state["checkout"] = checkout
             cruft_state["context"] = new_context
+            cruft_state["accept_hooks"] = accept_hooks_bool
             cruft_file.write_text(utils.cruft.json_dumps(cruft_state))
             typer.secho(
                 "Good work! Project's cruft has been updated and is as clean as possible!",

--- a/cruft/_commands/utils/generate.py
+++ b/cruft/_commands/utils/generate.py
@@ -26,6 +26,7 @@ def cookiecutter_template(
     output_dir: Path,
     repo: Repo,
     cruft_state: CruftState,
+    accept_hooks: bool,
     project_dir: Path = Path("."),
     cookiecutter_input: bool = False,
     checkout: Optional[str] = None,
@@ -43,7 +44,7 @@ def cookiecutter_template(
 
     assert repo.working_dir is not None  # nosec B101 (allow assert for type checking)
     context = _generate_output(
-        cruft_state, commit, Path(repo.working_dir), cookiecutter_input, output_dir
+        cruft_state, commit, Path(repo.working_dir), cookiecutter_input, output_dir, accept_hooks
     )
 
     # Get all paths that we are supposed to skip before generating the diff and applying updates
@@ -70,6 +71,7 @@ def _generate_output(
     project_dir: Path,
     cookiecutter_input: bool,
     output_dir: Path,
+    accept_hooks: bool,
 ) -> CookiecutterContext:
     inner_dir = project_dir / (cruft_state.get("directory") or "")
 
@@ -96,7 +98,11 @@ def _generate_output(
     with AltTemporaryDirectory(cruft_state.get("directory")) as tmpdir:
         # Kindly ask cookiecutter to generate the template
         template_dir = generate_files(
-            repo_dir=inner_dir, context=new_context, overwrite_if_exists=True, output_dir=tmpdir
+            repo_dir=inner_dir,
+            context=new_context,
+            overwrite_if_exists=True,
+            output_dir=tmpdir,
+            accept_hooks=accept_hooks,
         )
         template_dir = Path(template_dir)
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -62,6 +62,32 @@ def test_create_stores_checkout_value(value, tmpdir):
     )
 
 
+def test_create_with_hooks(tmpdir):
+    tmpdir.chdir()
+    accept_hooks = True
+    cruft.create(
+        "https://github.com/cruft/cookiecutter-test",
+        output_dir=Path(tmpdir),
+        directory="dir",
+        accept_hooks=accept_hooks,
+    )
+
+    assert json.load((tmpdir / "test" / ".cruft.json").open("r"))["accept_hooks"] == accept_hooks
+
+
+def test_create_without_hooks(tmpdir):
+    tmpdir.chdir()
+    accept_hooks = False
+    cruft.create(
+        "https://github.com/cruft/cookiecutter-test",
+        output_dir=Path(tmpdir),
+        directory="dir",
+        accept_hooks=accept_hooks,
+    )
+
+    assert json.load((tmpdir / "test" / ".cruft.json").open("r"))["accept_hooks"] == accept_hooks
+
+
 @pytest.mark.parametrize("value", ["main", None])
 def test_link_stores_checkout_value(value, tmpdir):
     project_dir = Path(tmpdir)
@@ -148,6 +174,33 @@ def test_update_locally_cloned_template(tmpdir):
         json.loads(utils.cruft.get_cruft_file(repo_dir).read_text())["template"]
         == cookiecutter_repo
     )
+
+
+def test_update_with_hooks(tmpdir):
+    tmpdir.chdir()
+    cruft.create(
+        "https://github.com/cruft/cookiecutter-test",
+        output_dir=Path(tmpdir),
+        directory="dir",
+        checkout="initial",
+    )
+    project_dir = tmpdir / "test"
+    assert cruft.update(Path(project_dir), checkout="updated", accept_hooks=False)
+    assert not json.load((project_dir / ".cruft.json").open("r"))["accept_hooks"]
+
+
+def test_update_without_hooks(tmpdir):
+    tmpdir.chdir()
+    cruft.create(
+        "https://github.com/cruft/cookiecutter-test",
+        output_dir=Path(tmpdir),
+        directory="dir",
+        checkout="initial",
+        accept_hooks=False,
+    )
+    project_dir = tmpdir / "test"
+    assert cruft.update(Path(project_dir), checkout="updated", accept_hooks=True)
+    assert json.load((project_dir / ".cruft.json").open("r"))["accept_hooks"]
 
 
 def test_relative_repo_check(tmpdir):
@@ -339,3 +392,25 @@ def test_diff_git_subdir(capfd, tmpdir):
     )
 
     assert cruft.update(project_dir, checkout="updated")
+
+
+def test_diff_with_hooks(tmpdir):
+    tmpdir.chdir()
+    cruft.create(
+        "https://github.com/cruft/cookiecutter-test",
+        output_dir=Path(tmpdir),
+        directory="dir",
+        checkout="initial",
+    )
+    assert cruft.diff(Path(tmpdir / "test"), checkout="updated", accept_hooks=True)
+
+
+def test_diff_without_hooks(tmpdir):
+    tmpdir.chdir()
+    cruft.create(
+        "https://github.com/cruft/cookiecutter-test",
+        output_dir=Path(tmpdir),
+        directory="dir",
+        checkout="initial",
+    )
+    assert cruft.diff(Path(tmpdir / "test"), checkout="updated", accept_hooks=False)


### PR DESCRIPTION
# Feature 
Allow usage of cookiecutters `accept_hooks` option

# Description

Added accept hooks option like in cookiecutter.
The used option is persisted in the cruft state as well to be used as an default for further actions.
This is especially helpful when diffing or upgrading projects that are based on templates with not replayable pre/post hooks.

# Changes in this PR
* Added `accept_hooks` option to create, update and diff task
* Link task uses a default of `True` for the `accept_hooks` option
* The used `accept_hooks` value is persisted in the cruft state up on create and update tasks

# Linked Issues
Closes  #199 
Closes #334